### PR TITLE
Add download as PNG button

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/rogeruiz/scuttle#readme",
   "devDependencies": {
     "babel-core": "^6.10.4",
+    "save-svg-as-png": "git://github.com/exupero/saveSvgAsPng#f56023b",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2016": "^6.11.0",
     "babelify": "^7.3.0",

--- a/source/html/render.html
+++ b/source/html/render.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <a class="usa-button usa-button-outline" href="/">Back to all diagrams</a>
+    <a class="usa-button usa-button-outline" id="save-png-button">Save as PNG</a>
     <div class="mermaid scuttle-stage" id="js-stage">
       {{ diagram-contents }}
     </div>

--- a/source/javascript/start.js
+++ b/source/javascript/start.js
@@ -1,10 +1,22 @@
 import mermaid from 'mermaid';
+import * as svgPng from 'save-svg-as-png';
 
 console.log( 'mermaid', mermaid.version() );
 
 // TODO This is very ugly, but for now it renders. This SVG creation should be
 // done in the build step.
 let ss = document.getElementById( 'js-stage' );
+let btn = document.getElementById( 'save-png-button' );
+btn.addEventListener('click', function() {
+  let svgList = ss.getElementsByTagName('svg');
+  let options = {
+    scale: 2,
+    backgroundColor: '#ffffff',
+  };
+  if (svgList.length) {
+    svgPng.saveSvgAsPng(svgList[0], document.title+'.png', options);
+  }
+});
 
 mermaid.mermaidAPI.render(
   'js-stage',


### PR DESCRIPTION
# What

Add the save-svg-as-png module and integrate with generated diagrams.